### PR TITLE
Feature: Debug info for AFL bitmap

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ sudo: required
 dist: xenial
 env:
   - PY=e ANGR_REPO=driller
-install: ( curl https://raw.githubusercontent.com/angr/angr-dev/$TRAVIS_BRANCH/travis-install.sh | grep -v 404 || curl https://raw.githubusercontent.com/angr/angr-dev/master/travis-install.sh ) | bash
-script: ~/angr-dev/travis-test.sh
+install: ( curl https://raw.githubusercontent.com/angr/angr-dev/$TRAVIS_BRANCH/tests/travis-install.sh | grep -v 404 || curl https://raw.githubusercontent.com/angr/angr-dev/master/tests/travis-install.sh ) | bash
+script: ~/angr-dev/tests/travis-test.sh

--- a/driller/config.py
+++ b/driller/config.py
@@ -24,6 +24,12 @@ DRILL_TIMEOUT=None
 
 MEM_LIMIT=None
 
+# where to write a debug file that contains useful debugging information like
+# AFL's fuzzing bitmap, input used, binary path, time started.
+# Uses following naming convention:
+#   <binary_basename>_<input_str_md5>.py
+DEBUG_DIR = None
+
 ### Fuzzer options
 
 # how often to check for crashes in seconds


### PR DESCRIPTION
This is useful if there is an error after AFL has tested a bunch of inputs and you want to debug as if you just started at that point again with the `fuzz_bitmap` that was used.

Maybe there is already a way to do this using the redis database? Not sure.