### PR TITLE
Feature: Use Seed Directory for Fuzzing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,5 @@ sudo: required
 dist: xenial
 env:
   - PY=e ANGR_REPO=driller
-install: ( curl https://raw.githubusercontent.com/angr/angr-dev/$TRAVIS_BRANCH/travis-install.sh | grep -v 404 || curl https://raw.githubusercontent.com/angr/angr-dev/master/travis-install.sh ) | bash
-script: ~/angr-dev/travis-test.sh
+install: ( curl https://raw.githubusercontent.com/angr/angr-dev/$TRAVIS_BRANCH/tests/travis-install.sh | grep -v 404 || curl https://raw.githubusercontent.com/angr/angr-dev/master/tests/travis-install.sh ) | bash
+script: ~/angr-dev/tests/travis-test.sh

--- a/driller/config.py
+++ b/driller/config.py
@@ -17,6 +17,8 @@ QEMU_DIR=None
 BINARY_DIR=None
 # directory containing the pcap corpus
 PCAP_DIR=None
+# directory containing the seeds for fuzzing
+SEED_DIR=None
 
 ### Driller options
 # how long to drill before giving up in seconds

--- a/driller/tasks.py
+++ b/driller/tasks.py
@@ -136,8 +136,10 @@ def _get_seeds():
     Search config.SEED_PATH for seed inputs.
     If no seed files are found, then seed with 'fuzz'.
     '''
+    default_seed = 'fuzz'
+
     if not config.SEED_DIR:
-        return ['fuzz']
+        return [default_seed]
 
     seed_path = config.SEED_DIR
     seeds = []
@@ -151,10 +153,10 @@ def _get_seeds():
 
         if len(seeds) == 0:
             l.warning("Seed directory has no seeds. Using default seed.")
-            seeds.append('fuzz')
+            seeds.append(default_seed)
     else:
         l.warning("Seeding with default as seed directory is not a valid path: %s", seed_path)
-        seeds.append('fuzz')
+        seeds.append(default_seed)
 
     return seeds
 


### PR DESCRIPTION
I saw that there was a `PCAP_DIR` for network traffic logs, but a path to a directory containing more general seeds might be better.

It would be a problem if both `SEED_DIR` and `PCAP_DIR` were defined: the files' contents in `PCAP_DIR` would replace the content of the files found in `SEED_DIR`. Do you think there should be a check or error if both are used? Should `PCAP_DIR` be removed completely (replaced by the more general `SEED_DIR`)?

Thank you!