### PR TITLE
Use binary reading mode for python3

### DIFF
--- a/driller/local_callback.py
+++ b/driller/local_callback.py
@@ -100,7 +100,7 @@ if __name__ == "__main__":
 
     binary_path, fuzzer_out_dir, bitmap_path, path_to_input_to_drill = sys.argv[1:5]
 
-    fuzzer_bitmap = open(args.bitmap_path, "r").read()
+    fuzzer_bitmap = open(args.bitmap_path, "rb").read()
 
     # create a folder
     driller_dir = os.path.join(args.fuzzer_out_dir, "driller")
@@ -112,7 +112,7 @@ if __name__ == "__main__":
 
     l.debug('drilling %s', path_to_input_to_drill)
     # get the input
-    inputs_to_drill = [open(args.path_to_input_to_drill, "r").read()]
+    inputs_to_drill = [open(args.path_to_input_to_drill, "rb").read()]
     if args.length_extension:
         inputs_to_drill.append(inputs_to_drill[0] + '\0' * args.length_extension)
 


### PR DESCRIPTION
In Python3, all raw binary data that opened by "r" mode are decoded as utf-8.
So sometimes following error happen.
```
UnicodeDecodeError: 'utf-8' codec can't decode byte 0xe3 in position 0: invalid continuation byte
```
We need to specify "rb" explicitly. 
