### PR TITLE
Update driller_main.py

### DIFF
--- a/driller/driller_main.py
+++ b/driller/driller_main.py
@@ -126,7 +126,7 @@ class Driller(object):
         simgr = p.factory.simulation_manager(s, save_unsat=True, hierarchy=False, save_unconstrained=r.crash_mode)
 
         t = angr.exploration_techniques.Tracer(trace=r.trace, crash_addr=r.crash_addr, copy_states=True)
-        self._core = angr.exploration_techniques.DrillerCore(trace=r.trace)
+        self._core = angr.exploration_techniques.DrillerCore(trace=r.trace, fuzz_bitmap=self.fuzz_bitmap)
 
         simgr.use_technique(t)
         simgr.use_technique(angr.exploration_techniques.Oppologist())


### PR DESCRIPTION
I have checked your scripts around Driller, and I think there is a problem in the driller_main.py script. When creating an object from DrillerCore, the value of fuzz_bitmap (that has been obtained from AFL) is not passed to its constructor. Consequently, the constructor will initialize self.fuzz_bitmap to the default value (namely, b"\xff" * 65536).