### PR TITLE
Use driller specific tracer exploration technique

### DIFF
--- a/driller/driller_main.py
+++ b/driller/driller_main.py
@@ -125,7 +125,7 @@ class Driller(object):
 
         simgr = p.factory.simulation_manager(s, save_unsat=True, hierarchy=False, save_unconstrained=r.crash_mode)
 
-        t = angr.exploration_techniques.Tracer(trace=r.trace, crash_addr=r.crash_addr, copy_states=True)
+        t = angr.exploration_techniques.Tracer(trace=r.trace, crash_addr=r.crash_addr, copy_states=True, follow_unsat=True)
         self._core = angr.exploration_techniques.DrillerCore(trace=r.trace, fuzz_bitmap=self.fuzz_bitmap)
 
         simgr.use_technique(t)


### PR DESCRIPTION
A new driller specific tracer exploration technique has been added to angr(see [this PR](https://github.com/angr/angr/pull/2582)). This PR updates driller to use that technique.